### PR TITLE
Adding serialisation capability

### DIFF
--- a/lib/bloomex.ex
+++ b/lib/bloomex.ex
@@ -243,7 +243,7 @@ defmodule Bloomex do
             ),
           any
         ) :: Bloomex.ScalableBloom.t()
-  def deserialise(bloom, func) do
+  def deserialise(bloom, func \\ fn x -> :erlang.phash2(x, 1 <<< 32) end) do
     %{
       "b" => b,
       "error_prob" => error_prob,

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,8 @@ defmodule Bloomex.Mixfile do
     [
       {:excoveralls, "~> 0.10", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.16", only: [:dev, :docs], runtime: false},
-      {:dialyzex, "~> 1.2.0", only: [:dev, :test], runtime: false}
+      {:dialyzex, "~> 1.2.0", only: [:dev, :test], runtime: false},
+      {:jason, "~> 1.1"}
     ]
   end
 


### PR DESCRIPTION
I had a requirement of storing the bloom filters in the database, so I created a serializer and a deserializer to convert the ScalableBloom filter structs to a JSON string.
```
b = Bloomex.scalable(1000, 0.1, 0.1, 2) 
json = Bloomex.serialise(b)
b1 = Bloomex.deserialise(json)
```